### PR TITLE
Publishable module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,19 +112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff-updater"
-version = "0.1.0"
-dependencies = [
- "json-patch",
- "neon",
- "neon-serde2",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +160,19 @@ dependencies = [
  "serde_json",
  "thiserror",
  "treediff",
+]
+
+[[package]]
+name = "json-patcher"
+version = "0.1.0"
+dependencies = [
+ "json-patch",
+ "neon",
+ "neon-serde2",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diff-updater"
+name = "json-patcher"
 version = "0.1.0"
 license = "ISC"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# diff-updater
+# json-patcher
 
 A JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7396) implementation for JS (browser and Node) using Rust.
 
@@ -8,21 +8,21 @@ This library is built with:
 
 Implementation of the patch and merge alogrithms is provided using [json-patch](https://docs.rs/json-patch/) crate.
 
-## Installing diff-updater
+## Installing json-patcher
 
-Installing diff-updater requires a [supported version of Node and Rust](https://github.com/neon-bindings/neon#platform-support).
+Installing json-patcher requires a [supported version of Node and Rust](https://github.com/neon-bindings/neon#platform-support).
 
 You can install the project with npm.
 
 ```sh
-$ npm install diff-updater
+$ npm install @formbird/json-patcher
 ```
 
 This fully installs the project, including installing any dependencies and running the build.
 
 ## Contributing
 
-### Building diff-updater
+### Building json-patcher
 
 Make sure you have Rust and [`wasm-bindgen`](https://rustwasm.github.io/wasm-bindgen/) installed. From the checked out source, run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,17 @@
 {
-    "name": "diff-updater",
+    "name": "@formbird/json-patcher",
     "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "diff-updater",
+            "name": "@formbird/json-patcher",
             "version": "0.1.0",
             "hasInstallScript": true,
             "devDependencies": {
                 "@types/node": "^20.1.5",
                 "ava": "^5.2.0",
                 "cargo-cp-artifact": "^0.1",
-                "rfc6902": "^5.0.1",
-                "structured-clone": "^0.2.2",
                 "typescript": "^5.0.4",
                 "vite": "^4.2.2",
                 "vite-plugin-top-level-await": "^1.3.0",
@@ -2168,12 +2166,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rfc6902": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.0.1.tgz",
-            "integrity": "sha512-tYGfLpKIq9X7lrt4o3IkD9w9bpeAtsejfAqWNR98AoxfTsZqCepKa8eDlRiX8QMiCOD9vMx0/YbKLx0G1nPi5w==",
-            "dev": true
-        },
         "node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -2362,12 +2354,6 @@
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
-        },
-        "node_modules/structured-clone": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/structured-clone/-/structured-clone-0.2.2.tgz",
-            "integrity": "sha512-SucNWVxwmfAjWrzQ9Xsuv4JIDtS/Qpx+MwZD2NEx2CeMpf3hgqvWKssll34trTu6M7ywd7WZDDKO8hhq0SZiAA==",
-            "dev": true
         },
         "node_modules/supertap": {
             "version": "3.0.1",
@@ -4068,12 +4054,6 @@
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
         },
-        "rfc6902": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.0.1.tgz",
-            "integrity": "sha512-tYGfLpKIq9X7lrt4o3IkD9w9bpeAtsejfAqWNR98AoxfTsZqCepKa8eDlRiX8QMiCOD9vMx0/YbKLx0G1nPi5w==",
-            "dev": true
-        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4189,12 +4169,6 @@
             "requires": {
                 "ansi-regex": "^6.0.1"
             }
-        },
-        "structured-clone": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/structured-clone/-/structured-clone-0.2.2.tgz",
-            "integrity": "sha512-SucNWVxwmfAjWrzQ9Xsuv4JIDtS/Qpx+MwZD2NEx2CeMpf3hgqvWKssll34trTu6M7ywd7WZDDKO8hhq0SZiAA==",
-            "dev": true
         },
         "supertap": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-    "name": "diff-updater",
+    "name": "@formbird/json-patcher",
     "version": "0.1.0",
     "description": "Diff Updater",
     "main": "node/index.js",
     "browser": "artifacts/browser.mjs",
+    "prviate": true,
     "types": "types.d.ts",
-    "repository": "https://github.com/formbird/diff-updater",
+    "repository": "https://github.com/formbird/json-patcher",
     "exclude": [
         "target/*",
         "artifacts/*"
@@ -22,7 +23,6 @@
         "pretest": "tsc -p test/tsconfig.json",
         "test": "ava"
     },
-    "license": "",
     "devDependencies": {
         "@types/node": "^20.1.5",
         "ava": "^5.2.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
     build: {
         lib: {
             entry: './browser/diff_updater.js',
-            name: 'diff-updater',
+            name: 'json-patcher',
             fileName: 'index',
             formats: ['es']
         },


### PR DESCRIPTION
This renames the module to json-patcher so that the name indicates that it uses JSONPatch, which is a standard. 

rfc6902 has been removed from the dependencies because it isn't needed to use the module.