### PR TITLE
Use gloo-utils for converting to JsValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-utils"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +179,7 @@ dependencies = [
 name = "json-patcher"
 version = "0.1.0"
 dependencies = [
+ "gloo-utils",
  "json-patch",
  "neon",
  "neon-serde2",
@@ -526,9 +540,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -536,24 +550,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.14",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -561,22 +575,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.14",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ features = ["napi-6"]
 neon-serde = { git = "https://github.com/formbird/neon-serde", package = "neon-serde2", features = ["dates"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.84"
+wasm-bindgen = "0.2.86"
 serde-wasm-bindgen = "0.5.0"
+gloo-utils = "0.1"

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 use json_patch::PatchOperation;
+use gloo_utils::format::JsValueSerdeExt;
 
 #[wasm_bindgen(js_name = createPatch)]
 pub fn create_patch(left: JsValue, right: JsValue) -> Result<String, serde_wasm_bindgen::Error> {
@@ -14,5 +15,5 @@ pub fn apply_patch(doc: JsValue, patches: JsValue) -> Result<JsValue, serde_wasm
     let mut doc = serde_wasm_bindgen::from_value(doc)?;
     let patches: Vec<PatchOperation> = serde_wasm_bindgen::from_value(patches)?;
     json_patch::patch(&mut doc, &patches).expect("todo");
-    serde_wasm_bindgen::to_value(&doc)
+    JsValue::from_serde(&doc).map_err(|e| serde_wasm_bindgen::Error::new(&e.to_string()))
 }


### PR DESCRIPTION
This ensures wasm and node functions have the same return types

Ref: https://github.com/cloudflare/serde-wasm-bindgen/issues/49