### PR TITLE
Handle dates specially

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,8 +388,7 @@ dependencies = [
 [[package]]
 name = "serde-wasm-bindgen"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+source = "git+https://github.com/hamza1311/serde-wasm-bindgen?branch=special-dates#0586dccdfb29803722c7a8757740a8897b9e4839"
 dependencies = [
  "js-sys",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,15 +25,18 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -37,28 +46,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time",
  "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
+ "windows-targets",
 ]
 
 [[package]]
@@ -68,54 +67,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.14",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.14",
-]
-
-[[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -127,25 +82,24 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -177,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -192,22 +146,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "neon"
@@ -253,7 +195,7 @@ dependencies = [
 [[package]]
 name = "neon-serde2"
 version = "0.8.0"
-source = "git+https://github.com/formbird/neon-serde#4f731c43e14c813673cb6b7ed1e0418f268cc137"
+source = "git+https://github.com/formbird/neon-serde#5daf25513b7ba7caead936184a913a9893ea7d3a"
 dependencies = [
  "chrono",
  "neon",
@@ -264,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -277,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -318,48 +260,42 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "semver"
@@ -378,9 +314,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -388,7 +324,7 @@ dependencies = [
 [[package]]
 name = "serde-wasm-bindgen"
 version = "0.5.0"
-source = "git+https://github.com/hamza1311/serde-wasm-bindgen?branch=special-dates#0586dccdfb29803722c7a8757740a8897b9e4839"
+source = "git+https://github.com/hamza1311/serde-wasm-bindgen?branch=special-dates#6f34e5fdbabea0df400efdf0cd33b64fec6a2bb4"
 dependencies = [
  "js-sys",
  "serde",
@@ -397,20 +333,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -419,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "syn"
@@ -436,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -447,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "syn-mid"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -457,32 +393,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -507,15 +434,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "wasi"
@@ -525,9 +446,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -535,24 +456,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -560,22 +481,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"
@@ -594,15 +515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -634,42 +546,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ neon-serde = { git = "https://github.com/formbird/neon-serde", package = "neon-s
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.86"
-serde-wasm-bindgen = "0.5.0"
+serde-wasm-bindgen = { git = "https://github.com/hamza1311/serde-wasm-bindgen", branch = "special-dates", features = ["special-dates"] }
 
 [profile.release]
 # less code to include into binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@formbird/json-patcher",
-    "version": "0.4.1",
+    "version": "0.6.0-pre.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@formbird/json-patcher",
-            "version": "0.4.1",
+            "version": "0.6.0-pre.0",
             "hasInstallScript": true,
             "license": "MIT OR Apache-2.0",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@formbird/json-patcher",
-    "version": "0.5.0",
+    "version": "0.6.0-pre.0",
     "description": "Diff Updater",
     "main": "node/index.js",
     "browser": "browser/index.mjs",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@ mod node;
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::*;
 
-pub use json_patch::{AddOperation, RemoveOperation, ReplaceOperation, MoveOperation, CopyOperation, TestOperation};
+pub use json_patch::{
+    AddOperation, CopyOperation, MoveOperation, RemoveOperation, ReplaceOperation, TestOperation,
+};
 
 #[cfg(target_arch = "wasm32")]
 mod wasm;

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,8 +19,8 @@ fn to_json_value<'a, D: DeserializeOwned>(
 ) -> Result<D, Throw> {
     match neon_serde::from_value(cx, js_value) {
         Ok(v) => Ok(v),
-        Err(neon_serde::errors::Error::Js(err)) => return Err(err),
-        Err(e) => return cx.throw_error(e.to_string()),
+        Err(neon_serde::errors::Error::Js(err)) => Err(err),
+        Err(e) => cx.throw_error(e.to_string()),
     }
 }
 
@@ -47,8 +47,8 @@ pub fn apply_patch(mut cx: FunctionContext) -> JsResult<JsValue> {
 
     match neon_serde::to_value(&mut cx, &doc) {
         Ok(v) => Ok(v),
-        Err(neon_serde::errors::Error::Js(err)) => return Err(err),
-        Err(e) => return cx.throw_error(e.to_string()),
+        Err(neon_serde::errors::Error::Js(err)) => Err(err),
+        Err(e) => cx.throw_error(e.to_string()),
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ fn to_json_value<'a, D: DeserializeOwned>(
     }
 }
 
-pub fn create_patch(mut cx: FunctionContext) -> JsResult<JsString> {
+pub fn create_patch(mut cx: FunctionContext) -> JsResult<JsValue> {
     let left = cx.argument::<JsValue>(0)?;
     let left = to_json_value(&mut cx, left)?;
 
@@ -32,8 +32,8 @@ pub fn create_patch(mut cx: FunctionContext) -> JsResult<JsString> {
     let right = to_json_value(&mut cx, right)?;
 
     let patch = json_patch::diff(&left, &right);
-    let s = map_to_neon!(cx, serde_json::to_string(&patch))?;
-    Ok(cx.string(s))
+    let s = map_to_neon!(cx, neon_serde::to_value(&mut cx, &patch))?;
+    Ok(s)
 }
 
 pub fn apply_patch(mut cx: FunctionContext) -> JsResult<JsValue> {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
-use wasm_bindgen::prelude::*;
 use json_patch::PatchOperation;
 use serde::ser::Serialize;
+use wasm_bindgen::prelude::*;
 
 fn to_value(value: impl Serialize) -> Result<JsValue, serde_wasm_bindgen::Error> {
     let ser = serde_wasm_bindgen::Serializer::json_compatible();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -2,12 +2,18 @@ use wasm_bindgen::prelude::*;
 use json_patch::PatchOperation;
 use serde::ser::Serialize;
 
+fn to_value(value: impl Serialize) -> Result<JsValue, serde_wasm_bindgen::Error> {
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    value.serialize(&ser)
+}
+
 #[wasm_bindgen(js_name = createPatch)]
-pub fn create_patch(left: JsValue, right: JsValue) -> Result<String, serde_wasm_bindgen::Error> {
+pub fn create_patch(left: JsValue, right: JsValue) -> Result<JsValue, serde_wasm_bindgen::Error> {
     let left = serde_wasm_bindgen::from_value(left)?;
     let right = serde_wasm_bindgen::from_value(right)?;
     let diff = json_patch::diff(&left, &right);
-    Ok(serde_json::to_string(&diff).expect("diff is valid json"))
+    let output = to_value(&diff)?;
+    Ok(output)
 }
 
 #[wasm_bindgen(js_name = applyPatch)]
@@ -15,6 +21,5 @@ pub fn apply_patch(doc: JsValue, patches: JsValue) -> Result<JsValue, serde_wasm
     let mut doc = serde_wasm_bindgen::from_value(doc)?;
     let patches: Vec<PatchOperation> = serde_wasm_bindgen::from_value(patches)?;
     json_patch::patch(&mut doc, &patches).expect("todo");
-    let ser = serde_wasm_bindgen::Serializer::json_compatible();
-    doc.serialize(&ser).map_err(|e| serde_wasm_bindgen::Error::new(&e.to_string()))
+    to_value(doc).map_err(|e| serde_wasm_bindgen::Error::new(&e.to_string()))
 }

--- a/test/_index.ts
+++ b/test/_index.ts
@@ -2,5 +2,5 @@ import {createPatch} from '..'
 
 export function createParsedPatch(input: any, output: any) {
   const patch = createPatch(input, output)
-  return JSON.parse(patch)
+  return patch
 }

--- a/test/_index.ts
+++ b/test/_index.ts
@@ -1,6 +1,0 @@
-import {createPatch} from '..'
-
-export function createParsedPatch(input: any, output: any) {
-  const patch = createPatch(input, output)
-  return patch
-}

--- a/test/arrays.spec.ts
+++ b/test/arrays.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
-import {applyPatch} from '..'
-import {createParsedPatch as createPatch} from "./_index";
+import {applyPatch, createPatch} from '..'
 
 
 const pairs = [

--- a/test/dates.spec.ts
+++ b/test/dates.spec.ts
@@ -11,13 +11,17 @@ it(`dates round trip`, () => {
     }
     const patch = createPatch(input, output)
     const actualOutput = applyPatch(input, patch)
+
     expect(actualOutput).to.deep.equal(output);
-    expect(actualOutput.date).to.be.instanceOf(Date)
+    // this is a way to check that the `actualOutput.date` is actually a date.
+    // for some reason, after going through neon, instanceof Date check fails _here_?
+    // this may have something to do with jest, as in neon_serde tests with mocha, the assertion is successful
+    expect(actualOutput.date.toISOString()).to.equal(output.date.toISOString())
+
 })
 
 it(`patch has special date string`, () => {
-    const input = {
-    }
+    const input = {}
     const output = {
         date: new Date(2023, 6, 9)
     }

--- a/test/dates.spec.ts
+++ b/test/dates.spec.ts
@@ -4,10 +4,16 @@ import {expect} from "chai";
 
 it(`dates round trip`, () => {
     const input = {
-        date: new Date(2023, 4, 20)
+        date: new Date(2023, 6, 9),
+        systemHeader: {
+            date: new Date(2023, 4, 20)
+        }
     }
     const output = {
-        date: new Date(2023, 6, 9)
+        date: new Date(2023, 4, 20),
+        systemHeader: {
+            date: new Date(2023, 6, 9)
+        }
     }
     const patch = createPatch(input, output)
     const actualOutput = applyPatch(input, patch)
@@ -17,7 +23,7 @@ it(`dates round trip`, () => {
     // for some reason, after going through neon, instanceof Date check fails _here_?
     // this may have something to do with jest, as in neon_serde tests with mocha, the assertion is successful
     expect(actualOutput.date.toISOString()).to.equal(output.date.toISOString())
-
+    expect(actualOutput.systemHeader.date.toISOString()).to.equal(output.systemHeader.date.toISOString())
 })
 
 it(`patch has special date string`, () => {

--- a/test/dates.spec.ts
+++ b/test/dates.spec.ts
@@ -1,0 +1,27 @@
+import {createParsedPatch as createPatch} from "./_index";
+import {applyPatch} from "..";
+import {expect} from "chai";
+
+it(`dates round trip`, () => {
+    const input = {
+        date: new Date(2023, 4, 20)
+    }
+    const output = {
+        date: new Date(2023, 6, 9)
+    }
+    const patch = createPatch(input, output)
+    const actualOutput = applyPatch(input, patch)
+    expect(actualOutput).to.deep.equal(output);
+    expect(actualOutput.date).to.be.instanceOf(Date)
+})
+
+it(`patch has special date string`, () => {
+    const input = {
+    }
+    const output = {
+        date: new Date(2023, 6, 9)
+    }
+    const patch = createPatch(input, output)
+    const op = patch[0]
+    expect(op.value.startsWith('$::date:')).to.be.true
+})

--- a/test/dates.spec.ts
+++ b/test/dates.spec.ts
@@ -41,11 +41,12 @@ it(`dates round trip`, () => {
 })
 
 it(`patch includes dates`, () => {
+    const date = new Date()
     const input = {}
     const output = {
-        date: new Date(2023, 6, 9)
+        date
     }
     const patch = createPatch(input, output)
     const op = patch[0]
-    expect(op.value.toISOString()).to.equal("2023-07-08T19:00:00.000Z")
+    expect(op.value.toISOString()).to.equal(date.toISOString())
 })

--- a/test/dates.spec.ts
+++ b/test/dates.spec.ts
@@ -1,5 +1,4 @@
-import {createParsedPatch as createPatch} from "./_index";
-import {applyPatch} from "..";
+import {applyPatch, createPatch} from "..";
 import {expect} from "chai";
 
 it(`dates round trip`, () => {
@@ -41,12 +40,12 @@ it(`dates round trip`, () => {
 
 })
 
-it(`patch has special date string`, () => {
+it(`patch includes dates`, () => {
     const input = {}
     const output = {
         date: new Date(2023, 6, 9)
     }
     const patch = createPatch(input, output)
     const op = patch[0]
-    expect(op.value.startsWith('$::date:')).to.be.true
+    expect(op.value.toISOString()).to.equal("2023-07-08T19:00:00.000Z")
 })

--- a/test/dates.spec.ts
+++ b/test/dates.spec.ts
@@ -7,14 +7,26 @@ it(`dates round trip`, () => {
         date: new Date(2023, 6, 9),
         systemHeader: {
             date: new Date(2023, 4, 20)
-        }
-    }
+        },
+        arr: [
+            new Date(2023, 4, 20),
+            {
+                date: new Date(2023, 4, 20)
+            },
+        ]
+    } as const
     const output = {
         date: new Date(2023, 4, 20),
         systemHeader: {
             date: new Date(2023, 6, 9)
-        }
-    }
+        },
+        arr: [
+            new Date(2023, 6, 9),
+            {
+                date: new Date(2023, 6, 9)
+            }
+        ]
+    } as const
     const patch = createPatch(input, output)
     const actualOutput = applyPatch(input, patch)
 
@@ -24,6 +36,9 @@ it(`dates round trip`, () => {
     // this may have something to do with jest, as in neon_serde tests with mocha, the assertion is successful
     expect(actualOutput.date.toISOString()).to.equal(output.date.toISOString())
     expect(actualOutput.systemHeader.date.toISOString()).to.equal(output.systemHeader.date.toISOString())
+    expect(actualOutput.arr[0].toISOString()).to.equal(output.arr[0].toISOString())
+    expect(actualOutput.arr[1].date.toISOString()).to.equal(output.arr[1].date.toISOString())
+
 })
 
 it(`patch has special date string`, () => {

--- a/test/roundtrips.spec.ts
+++ b/test/roundtrips.spec.ts
@@ -1,5 +1,4 @@
-import {applyPatch, type PatchOperation} from "..";
-import { createParsedPatch as createPatch } from './_index'
+import {applyPatch, type PatchOperation, createPatch} from "..";
 import { expect } from 'chai'
 
 function checkRoundtrip(

--- a/test/specification.spec.ts
+++ b/test/specification.spec.ts
@@ -44,7 +44,7 @@ spec_data.filter(spec => spec.diffable).forEach(spec => {
     runCatching(spec, () => {
       const actual = createPatch(spec.input, spec.output)
       const expected = spec.patch.filter(operation => operation.op !== 'test')
-      expect(JSON.parse(actual)).to.deep.equal(expected)
+      expect(actual).to.deep.equal(expected)
     })
   })
 })


### PR DESCRIPTION
This PR uses fork of `serde-wasm-bindgen` with special dates handling (https://github.com/cloudflare/serde-wasm-bindgen/pull/55). All date objects are deserialized to ISO timestamp strings, prefixed with `$::date:`. When serializing back to `JsValue`, strings with that prefix are converted to Date objects