### PR TITLE
feat: include typescript definitions in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "src/*",
         "browser/**/*",
         "node/index.js",
+        "types.d.ts",
         "README.md"
     ],
     "scripts": {


### PR DESCRIPTION
Adds `types.d.ts` file to `files`-array in `package.json`

fixes #19 